### PR TITLE
feat(dsp): add RMS and Peak normalization modes with gain handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ include_directories(${FFMPEG_INCLUDE_DIRS})
 include(src/dsp/echo/echo.cmake)
 include(src/dsp/gain/gain.cmake)
 include(src/dsp/fade/fade.cmake)
+include(src/dsp/normalization/norm.cmake)
 
 # Create the engine library
 add_library(aj_audio_engine
@@ -33,7 +34,7 @@ add_library(aj_audio_engine
 
 # Link dependencies to the engine library
 target_link_libraries(aj_audio_engine
-    PRIVATE echo_avx echo_sse gain_avx fade_avx ${SNDFILE_LIBRARY} ${FFMPEG_LIBRARIES}
+    PRIVATE echo_avx echo_sse gain_avx fade_avx norm_gain_avx ${SNDFILE_LIBRARY} ${FFMPEG_LIBRARIES}
 )
 
 target_include_directories(aj_audio_engine PRIVATE ${FFMPEG_INCLUDE_DIRS})
@@ -66,5 +67,5 @@ target_include_directories(test PRIVATE ${FFMPEG_INCLUDE_DIRS})
 
 # Link all libraries to test executable
 target_link_libraries(test
-    PRIVATE echo_avx echo_sse gain_avx fade_avx ${SNDFILE_LIBRARY} ${FFMPEG_LIBRARIES}
+    PRIVATE echo_avx echo_sse gain_avx fade_avx norm_gain_avx ${SNDFILE_LIBRARY} ${FFMPEG_LIBRARIES}
 )

--- a/cmake/common_sources/common_sources.cmake
+++ b/cmake/common_sources/common_sources.cmake
@@ -12,5 +12,7 @@ set(COMMON_SOURCES
     src/dsp/reverb/reverb.cc
     
     src/dsp/fade/fade.cc
+    src/dsp/normalization/normalization.cc
+    src/dsp/normalization/gain.cc
 )
 

--- a/cmake/common_test_sources/common_test_sources.cmake
+++ b/cmake/common_test_sources/common_test_sources.cmake
@@ -7,4 +7,5 @@ set(COMMON_TEST_SOURCES
     test/gain/gain_tests.cc
     test/reverb/reverb_tests.cc
     test/fade/fade_tests.cc
+    test/normalization/norm_tests.cc
 )

--- a/include/dsp/fade.h
+++ b/include/dsp/fade.h
@@ -53,8 +53,8 @@ public:
      * 
      * @return Shared pointer to a valid FadeParams instance, or nullptr if parameters are invalid.
      */
-    std::shared_ptr<FadeParams> create(const sample_pos& start, const sample_pos& end,
-        const float& highGain, const float& lowGain, const FadeMode& mode, AJ::error::IErrorHandler &handler);
+    static std::shared_ptr<FadeParams> create(sample_pos& start, sample_pos& end,
+        float& highGain, float& lowGain, FadeMode& mode, AJ::error::IErrorHandler &handler);
 
     /// @return Gain at the loud end of the fade.
     float highGain() { return mHighGain; }
@@ -204,7 +204,7 @@ public:
      * 
      * @return true if parameters were successfully assigned, false otherwise.
      */
-    bool setParams(std::shared_ptr<EffectParams> params, AJ::error::IErrorHandler &handler);
+    bool setParams(std::shared_ptr<EffectParams> params, AJ::error::IErrorHandler &handler) override;
 };
 
 }; // namespace AJ::dsp

--- a/include/dsp/gain.h
+++ b/include/dsp/gain.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <iostream>
+#include <memory>
 
 #include "effect.h"
 #include "core/types.h"
@@ -85,15 +86,15 @@ public:
      * @brief Set the gain value after validating it.
      * Can also be used to mute audio by setting the gain to 0.0f.
      * 
-     * @param gain The new gain value to apply. Must be in [0.0, 2.0].
+     * @param gain The new gain value to apply. Must be in [0.0, 5.0].
      * @param handler Error handler to report invalid gain.
      * 
      * @return true if the gain is valid and applied, false otherwise.
      */
     bool setGain(gain_t gain, AJ::error::IErrorHandler &handler) {
-        if (gain < 0.0 || gain > 2.0) {
+        if (gain < 0.0 || gain > 5.0) {
             const std::string message = "Invalid gain: " + std::to_string(gain) 
-                + " Gain must be in range of [0.0, 2.0]\n";
+                + " Gain must be in range of [0.0, 5.0]\n";
 
             handler.onError(error::Error::InvalidEffectParameters, message);
             return false;

--- a/include/dsp/normalization.h
+++ b/include/dsp/normalization.h
@@ -1,11 +1,226 @@
-// #pragma once
-// #include "effect.h"
+#pragma once
 
+#include <algorithm>
+#include <memory>
+#include <cmath>
 
-// namespace AJ::dsp {
-//     class Normalization : public AJ::dsp::Effect {
-//     public:
-//         void process(AudioBuffer &buffer, sample_pos start, sample_pos end, short chan) override;
+#include "effect.h"
+#include "core/effect_params.h"
 
-//     };
-// };
+namespace AJ::dsp {
+
+/**
+ * @brief Modes of normalization.
+ *
+ * - Peak: Scales audio so that the highest peak reaches the target amplitude.
+ * - RMS:  Scales audio so that the RMS (Root Mean Square) value reaches the target amplitude.\
+ * 
+ * * NOTE: RMS normalization in this implementation is not fully tuned for
+ *   practical use — it may produce excessive gain for low-level or sparse audio.
+ */
+enum NormalizationMode {
+    Peak,  ///< Peak normalization mode.
+    RMS,   ///< RMS normalization mode.
+};
+
+/**
+ * @brief Parameters for the Normalization effect.
+ *
+ * Stores target amplitude, selected normalization mode,
+ * and computed gain value. Provides clamped setters to ensure
+ * parameters stay within valid ranges.
+ */
+class NormalizationParams : public EffectParams {
+    float mTarget;               ///< Target amplitude (linear scale, [0.0f, 1.0f]).
+    float mGain;                 ///< Computed gain factor to apply.
+    NormalizationMode mMode;     ///< Selected normalization mode.
+
+    struct PrivateTag {};        ///< Tag for private constructor to enforce factory creation.
+public:
+    /**
+     * @brief Factory method to create a NormalizationParams instance.
+     * 
+     * Validates and constructs parameters for a Normalization effect. 
+     * 
+     * @param start     Sample position where normalization starts.
+     * @param end       Sample position where normalization ends (inclusive).
+     * @param handler   Error handler for parameter validation failures.
+     * @param target    Normalization target (linear, not dBFS) in range [0.0f, 1.0f]. Default = 1.0f.
+     * @param mode      Normalization mode (NormalizationMode::Peak or NormalizationMode::RMS). Default = Peak.
+     * 
+     * @return Shared pointer to a valid NormalizationParams instance, or nullptr if parameters are invalid.
+     */
+    static std::shared_ptr<NormalizationParams> create(sample_pos& start, sample_pos& end,
+        AJ::error::IErrorHandler &handler, float target = 1.0f,
+        NormalizationMode mode = NormalizationMode::Peak);
+
+    /// @return The current target amplitude (linear).
+    float Target(){
+        return mTarget;
+    }
+
+    /**
+     * @brief Set the target amplitude (linear scale).
+     * @param factor Target amplitude in range [0.0f, 1.0f].
+     */
+    void setTarget(float factor){
+        mTarget = std::clamp(factor, 0.0f, 1.0f);
+    }
+
+    /// @return The current normalization mode.
+    NormalizationMode Mode(){
+        return mMode;
+    }
+
+    /**
+     * @brief Set the normalization mode.
+     * @param mode NormalizationMode::Peak or NormalizationMode::RMS.
+     */
+    void setMode(NormalizationMode mode){
+        mMode = mode;
+    }
+
+    /// @return The current gain factor.
+    float Gain(){
+        return mGain;
+    }
+
+    /**
+     * @brief Set the gain factor.
+     * @param gain Gain multiplier, clamped to [0.0f, 5.0f].
+     */
+    void setGain(float gain){
+        mGain = std::clamp(gain, 0.0f, 5.0f);
+    }
+
+    /**
+     * @brief Private constructor for controlled instantiation.
+     */
+    NormalizationParams(PrivateTag){
+        mTarget = 1.0f;
+        mMode = NormalizationMode::Peak;
+    }
+};
+
+/**
+ * @brief Normalization effect.
+ *
+ * Applies gain to audio samples to achieve a specified
+ * target amplitude, either by peak normalization or RMS normalization.
+ * In RMS mode, a peak clamp is applied to avoid clipping.
+ *
+ * TODO: Fix RMS Function.
+ */
+class Normalization : public AJ::dsp::Effect {
+
+    std::shared_ptr<NormalizationParams> mParams; ///< Effect parameters.
+
+    /**
+     * @brief Applies gain using AVX vectorization without clamping.
+     * 
+     * Optimized for Peak normalization where clamping is unnecessary.  
+     * Uses AVX instructions to process multiple samples in parallel.
+     * 
+     * @param buffer   Audio buffer to be modified in-place.
+     * @param handler  Error handler for processing errors.
+     * 
+     * @return true if processing was successful, false otherwise.
+     */
+    bool gainAVX(Float &buffer, AJ::error::IErrorHandler &handler);
+
+    /**
+     * @brief Applies gain using a naive scalar loop without clamping.
+     * 
+     * Intended for Peak normalization when vectorization is not available  
+     * or AVX optimization is disabled.
+     * 
+     * @param buffer   Audio buffer to be modified in-place.
+     * @param handler  Error handler for processing errors.
+     * 
+     * @return true if processing was successful, false otherwise.
+     */
+    bool gainNaive(Float &buffer, AJ::error::IErrorHandler &handler);
+
+    /**
+     * @brief Dispatches to the appropriate gain function (AVX or naive).
+     * 
+     * Automatically selects between AVX and naive implementations  
+     * based on platform capabilities and compile-time configuration.
+     * 
+     * @param buffer   Audio buffer to be modified in-place.
+     * @param handler  Error handler for processing errors.
+     * 
+     * @return true if processing was successful, false otherwise.
+     */
+    bool gain(Float &buffer, AJ::error::IErrorHandler &handler);
+
+    /**
+     * @brief Performs RMS-based normalization.
+     * 
+     * Adjusts gain so that the Root Mean Square (RMS) level matches the target.  
+     * Includes a basic peak limiter to reduce excessive gain.  
+     * 
+     * @warning Current implementation may produce unpredictable results  
+     * for low-level or sparse audio. Peak normalization is recommended.
+     * 
+     * @param buffer   Audio buffer to be normalized in-place.
+     * @param handler  Error handler for processing errors.
+     * 
+     * @return true if processing was successful, false otherwise.
+     */
+    bool normalizationRMS(Float &buffer, AJ::error::IErrorHandler &handler);
+
+    /**
+     * @brief Performs Peak-based normalization.
+     * 
+     * Scales the audio buffer so the highest absolute sample reaches the target.  
+     * This method is fast, predictable, and safe for production use.
+     * 
+     * @param buffer   Audio buffer to be normalized in-place.
+     * @param handler  Error handler for processing errors.
+     * 
+     * @return true if processing was successful, false otherwise.
+     */
+    bool normalizationPeak(Float &buffer, AJ::error::IErrorHandler &handler);
+
+public:
+    /// @brief Default constructor.
+    Normalization(){
+        mParams = nullptr;
+    }
+
+    /**
+     * @brief Construct with parameters.
+     * @param params   Normalization parameters.
+     * @param handler  Error handler for validation.
+     */
+    Normalization(std::shared_ptr<EffectParams> params, AJ::error::IErrorHandler &handler){
+        setParams(params, handler);
+    }
+
+    /**
+     * @brief Process the audio buffer using the selected normalization mode.
+     * 
+     * @param buffer   Audio samples to process.
+     * @param handler  Error handler for reporting processing issues.
+     * 
+     * @return true if processing was successful, false otherwise.
+     */
+    bool process(Float &buffer, AJ::error::IErrorHandler &handler) override;
+
+    /**
+     * @brief Assigns normalization parameters to the effect.
+     * 
+     * Verifies that the passed `EffectParams` pointer is of type `NormalizationParams`.  
+     * If type mismatch occurs, an error is reported via the handler and 
+     * parameters are not updated.
+     * 
+     * @param params   Shared pointer to `NormalizationParams` object.
+     * @param handler  Error handler for reporting validation failures.
+     * 
+     * @return true if parameters were successfully assigned, false otherwise.
+     */
+    bool setParams(std::shared_ptr<EffectParams> params, AJ::error::IErrorHandler &handler) override;
+};
+
+}; // namespace AJ::dsp

--- a/src/dsp/fade/fade.cc
+++ b/src/dsp/fade/fade.cc
@@ -5,8 +5,8 @@
 #include "core/types.h"
 #include "core/error_handler.h"
 
-std::shared_ptr<AJ::dsp::FadeParams> AJ::dsp::FadeParams::create(const sample_pos& start, const sample_pos& end,
-    const float& highGain, const float& lowGain, const FadeMode& mode, AJ::error::IErrorHandler &handler){
+std::shared_ptr<AJ::dsp::FadeParams> AJ::dsp::FadeParams::create(sample_pos& start, sample_pos& end,
+    float& highGain, float& lowGain, FadeMode& mode, AJ::error::IErrorHandler &handler){
 
     if(lowGain > highGain){
         const std::string message = "invalid gain parameters for fade effect.\n";
@@ -28,7 +28,7 @@ std::shared_ptr<AJ::dsp::FadeParams> AJ::dsp::FadeParams::create(const sample_po
 
 bool AJ::dsp::Fade::setParams(std::shared_ptr<EffectParams> params, AJ::error::IErrorHandler &handler){
     std::shared_ptr<FadeParams> fadeParams = std::dynamic_pointer_cast<FadeParams>(params);
-    // if fadeInParams is nullptr that means it's not a shared_ptr of fadeInParams
+    // if fadeParams is nullptr that means it's not a shared_ptr of FadeParams
     if(!fadeParams){
         const std::string message = "Effect parameters must be of type FadeParams for this effect.\n";
         handler.onError(error::Error::InvalidEffectParameters, message);

--- a/src/dsp/gain/gain.cc
+++ b/src/dsp/gain/gain.cc
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <memory>
 #include "core/types.h"
 
 #include "dsp/effect.h"

--- a/src/dsp/normalization/gain.cc
+++ b/src/dsp/normalization/gain.cc
@@ -1,0 +1,32 @@
+#include <iostream>
+ 
+#include "dsp/normalization.h"
+#include "core/types.h"
+#include "core/error_handler.h"
+
+bool AJ::dsp::Normalization::gain(Float &buffer, AJ::error::IErrorHandler &handler){
+    if(mParams->Gain() == 1.0f) return true;
+    
+#if defined(__AVX__)
+    if (__builtin_cpu_supports("avx")) {
+        return gainAVX(buffer, handler);
+    }
+#endif
+
+    return gainNaive(buffer, handler);
+}
+
+bool AJ::dsp::Normalization::gainNaive(Float &buffer, AJ::error::IErrorHandler &handler){
+    if(mParams->mEnd < mParams->mStart || mParams->mStart < 0 || 
+        mParams->mStart >= buffer.size() || mParams->mEnd >= buffer.size()){
+        const std::string message = "invalid indexes for gain effect.";
+        handler.onError(error::Error::InvalidEffectParameters, message);
+        return false;
+    }
+
+    for(sample_pos i = mParams->mStart; i <= mParams->mEnd; ++i){
+        buffer[i] *= mParams->Gain();
+    }
+
+    return true;
+}

--- a/src/dsp/normalization/norm.cmake
+++ b/src/dsp/normalization/norm.cmake
@@ -1,0 +1,8 @@
+# gain AVX Sources
+add_library(
+    norm_gain_avx STATIC src/dsp/normalization/gain_avx.cc
+)
+
+target_compile_options(
+    norm_gain_avx PRIVATE -mavx
+)

--- a/src/dsp/normalization/normalization.cc
+++ b/src/dsp/normalization/normalization.cc
@@ -1,0 +1,153 @@
+#include <iostream>
+#include <algorithm>
+#include <memory>
+#include <cmath>
+
+#include "dsp/normalization.h"
+#include "dsp/gain.h"
+#include "core/types.h"
+#include "core/error_handler.h"
+
+std::shared_ptr<AJ::dsp::NormalizationParams> AJ::dsp::NormalizationParams::create(sample_pos& start,
+    sample_pos& end, AJ::error::IErrorHandler &handler, float target, NormalizationMode mode){
+
+    std::shared_ptr<NormalizationParams> params = std::make_shared<NormalizationParams>(PrivateTag{});
+        
+    if(start > end || start < 0) {
+        const std::string message = "invalid range indexes parameters for normalization effect.\n";
+        handler.onError(error::Error::InvalidEffectParameters, message);
+
+        return nullptr;
+    }
+
+    params->setTarget(target);
+    params->mStart = start;
+    params->mEnd = end;
+    params->mMode = mode;
+
+    return params;
+}
+
+bool AJ::dsp::Normalization::setParams(std::shared_ptr<EffectParams> params, AJ::error::IErrorHandler &handler){
+    std::shared_ptr<NormalizationParams> normalizationParams = std::dynamic_pointer_cast<NormalizationParams>(params);
+    // if normalizationParams is nullptr that means it's not a shared_ptr of normalizationParams
+    if(!normalizationParams){
+        const std::string message = "Effect parameters must be of type NormalizationParams for this effect.\n";
+        handler.onError(error::Error::InvalidEffectParameters, message);
+        return false;
+    }
+
+    mParams = normalizationParams; 
+    return true;
+}
+
+bool AJ::dsp::Normalization::process(Float &buffer, AJ::error::IErrorHandler &handler){
+    if(mParams->Mode() == NormalizationMode::Peak)
+        return normalizationPeak(buffer, handler);
+    
+    return normalizationRMS(buffer, handler);
+}
+
+bool AJ::dsp::Normalization::normalizationPeak(Float &buffer, AJ::error::IErrorHandler &handler){
+    /**
+     * Peak normalization adjusts audio so that the loudest sample
+     * reaches a user-defined target peak level.
+     *
+     * Steps:
+     * 1. Find the maximum absolute sample value in the buffer:
+     *        max_sample = max(max_sample, abs(current_sample))
+     *
+     * 2. Calculate the gain needed to make this peak match the target:
+     *        gain = target / max_sample
+     *
+     * 3. Multiply all samples by the gain:
+     *        buffer[i] *= gain;
+     *
+     * Notes:
+     * - If the target is lower than the current peak, the gain will be < 1.0,
+     *   which reduces the volume instead of increasing it. This is perfectly
+     *   valid and is used to attenuate audio.
+     */
+
+
+    // find the max:
+    float max_sample = -1.0f;
+
+    for(size_t i = mParams->mStart; i <= mParams->mEnd; ++i)
+        max_sample = std::max(max_sample, std::abs(buffer[i]));
+
+    
+    // calc gain:
+    float gain_factor = mParams->Target() / max_sample;
+    mParams->setGain(gain_factor);
+
+    // use special gain functionality that doesn't need clamping
+
+
+    return gain(buffer, handler);
+}
+
+// TODO: change the code if abstract factory used for gain
+bool AJ::dsp::Normalization::normalizationRMS(Float &buffer, AJ::error::IErrorHandler &handler){
+    /**
+     * RMS normalization process (current implementation):
+     *
+     * 1. Compute the RMS (Root Mean Square) of all samples:
+     *      sum_sq = sum(sample^2) for each sample
+     *      mean_sq = sum_sq / num_samples
+     *      RMS = sqrt(mean_sq)
+     *
+     * 2. Compute peak amplitude across the same range:
+     *      max_sample = max(abs(sample))
+     *
+     * 3. Calculate desired RMS gain:
+     *      gain_rms = target_linear / RMS
+     *
+     * 4. Calculate peak-safe gain (to prevent clipping):
+     *      gain_peak = target_linear / max_sample
+     *
+     * 5. Use the smaller of the two gains:
+     *      gain = min(gain_rms, gain_peak)
+     *
+     * 6. Apply the gain to all samples:
+     *      sample *= gain
+     *
+     * NOTE: This approach effectively performs RMS normalization
+     *       but clamps it using peak normalization to avoid clipping.
+     *
+     * TODO: Replace the simple gain clamp with a proper peak limiter
+     */
+
+
+    double sum_sq = 0.0f;
+    float max_sample = -1.0f;
+    for(size_t i = mParams->mStart; i <= mParams->mEnd; ++i){
+        sum_sq += std::pow(buffer[i], 2);
+        max_sample = std::max(max_sample, std::abs(buffer[i]));
+    }
+
+    float mean_sq = sum_sq / (mParams->mEnd - mParams->mStart + 1);
+
+    float RMS = std::sqrt(mean_sq);
+
+    float gain = mParams->Target() / RMS;
+
+    // peak limiting.
+    gain = std::min(gain, mParams->Target() / max_sample);
+
+    mParams->setGain(gain);
+
+    // start applying gain
+    std::shared_ptr<AJ::dsp::GainParams> gainParams = 
+        std::make_shared<AJ::dsp::GainParams>(mParams->mStart, mParams->mEnd); 
+    
+    gainParams->mGain = mParams->Gain();
+
+    AJ::dsp::Gain Gain;
+
+    if(!Gain.setParams(gainParams, handler)){
+        return false;
+    }
+
+    return Gain.process(buffer, handler);
+}

--- a/test/fade/fade_tests.cc
+++ b/test/fade/fade_tests.cc
@@ -131,7 +131,9 @@ private:
         sample_pos start = info.length; // invalid
         sample_pos end = info.length / 2;
 
-        auto params = AJ::dsp::FadeParams::create(start, end, 1.0f, 0.0f, FadeMode::In, errorHandler);
+        float high = 1.0f, low = 0.0f;
+        FadeMode mode = FadeMode::In;
+        auto params = AJ::dsp::FadeParams::create(start, end, high, low, mode, errorHandler);
         assert(params);
         assert(fadeEffect.setParams(params, errorHandler));
 

--- a/test/normalization/norm_tests.cc
+++ b/test/normalization/norm_tests.cc
@@ -1,0 +1,152 @@
+#include <iostream>
+#include <chrono>
+#include <cassert>
+#include <filesystem>
+#include <cmath>
+
+#include "dsp/normalization.h"
+#include "file_io/wav_file.h"
+#include "core/error_handler.h"
+
+namespace fs = std::filesystem;
+
+class NormalizationTests {
+public:
+    static void run_all() {
+        std::cout << "\nRunning Normalization Processing Tests (Peak & RMS)\n";
+        std::cout << "--------------------------------------------------\n";
+
+        // Peak normalization - full file
+        test_normalization("long_audio.wav", 2, "full", AJ::dsp::NormalizationMode::Peak, 1.0f);
+        
+        // RMS normalization - full file
+        test_normalization("test_24bit_stereo.wav", 2, "full", AJ::dsp::NormalizationMode::RMS, 0.5f);
+
+        // Peak normalization - partial segment
+        test_normalization("test_32bit_float_mono.wav", 1, "partial", AJ::dsp::NormalizationMode::Peak, 0.5f);
+
+        // RMS normalization - partial segment
+        test_normalization("test_32bit_int_stereo.wav", 2, "partial", AJ::dsp::NormalizationMode::RMS, 0.9f);
+
+        // Factor beyond allowed range (should clamp internally)
+        test_normalization("test_64bit_double_mono.wav", 1, "full", AJ::dsp::NormalizationMode::Peak, 0.2f);
+
+        // Invalid range test
+        // test_normalization_invalid_range("long_audio.wav", 2);
+
+        std::cout << "All Normalization Tests Completed Successfully.\n";
+    }
+
+private:
+    static constexpr const char* audio_dir =
+        "/home/aj-e/Programming Codes/C++/AJ-Audio-Engine/build/build/bin/audio";
+    static constexpr const char* output_dir =
+        "/home/aj-e/Programming Codes/C++/AJ-Audio-Engine/build/build/bin/norm_audio";
+
+    static void test_normalization(const std::string& filename,
+                                   short expected_channels,
+                                   const std::string& mode,
+                                   AJ::dsp::NormalizationMode norm_mode,
+                                   float factor) {
+        using namespace AJ;
+        using namespace AJ::io;
+        using namespace AJ::dsp;
+
+        std::string input_path = std::string(audio_dir) + "/" + filename;
+        WAV_File wav;
+        error::ConsoleErrorHandler errorHandler;
+
+        assert(wav.setFilePath(input_path));
+        assert(wav.setFileName(const_cast<std::string&>(filename)));
+
+        auto read_start = std::chrono::high_resolution_clock::now();
+        bool read_success = wav.read(errorHandler);
+        auto read_end = std::chrono::high_resolution_clock::now();
+        assert(read_success);
+
+        std::chrono::duration<double> read_time = read_end - read_start;
+        std::cout << "\nTest: Normalization (" 
+                  << (norm_mode == NormalizationMode::Peak ? "Peak" : "RMS")
+                  << ") on " << filename << "\n";
+        std::cout << "Read Time: " << read_time.count() << "s\n";
+
+        const auto& info = wav.mInfo;
+        assert(info.channels == expected_channels);
+
+        AudioSamples pAudio = wav.pAudio;
+        assert(pAudio);
+
+        sample_pos start = 0;
+        sample_pos end = (info.length / info.channels) - 1;
+        if (mode == "partial") {
+            start = 5 * info.samplerate; // start at 5s
+            end /= 2;
+        }
+
+        auto params = NormalizationParams::create(start, end, errorHandler, factor, norm_mode);
+        assert(params);
+
+        Normalization normalization(params, errorHandler);
+
+        auto process_start = std::chrono::high_resolution_clock::now();
+        normalization.process((*pAudio)[0], errorHandler);
+        if (info.channels > 1) {
+            normalization.process((*pAudio)[1], errorHandler);
+        }
+        auto process_end = std::chrono::high_resolution_clock::now();
+
+        std::chrono::duration<double> process_time = process_end - process_start;
+        std::cout << "Processing Time: " << process_time.count() << "s\n";
+
+        AudioWriteInfo write_info {
+            info.length, info.samplerate, info.channels,
+            info.bitdepth, ".wav", true,
+            std::string(output_dir),
+            "norm_" + (norm_mode == NormalizationMode::Peak ? std::string("peak") : std::string("rms"))
+                     + "_" + mode + "_" + filename
+        };
+
+        auto write_start = std::chrono::high_resolution_clock::now();
+        assert(wav.setWriteInfo(write_info, errorHandler));
+        assert(wav.write(errorHandler));
+        auto write_end = std::chrono::high_resolution_clock::now();
+
+        std::chrono::duration<double> write_time = write_end - write_start;
+        std::cout << "Write Time: " << write_time.count() << "s\n";
+        std::cout << "Wrote: " << write_info.path << "/" << write_info.name << ".wav\n";
+        std::cout << "--------------------------------------------------\n";
+    }
+
+    static void test_normalization_invalid_range(const std::string& filename,
+                                                 short expected_channels) {
+        using namespace AJ;
+        using namespace AJ::io;
+        using namespace AJ::dsp;
+
+        error::ConsoleErrorHandler errorHandler;
+        WAV_File wav;
+
+        std::string input_path = std::string(audio_dir) + "/" + filename;
+        assert(wav.setFilePath(input_path));
+        assert(wav.setFileName(const_cast<std::string&>(filename)));
+        assert(wav.read(errorHandler));
+
+        std::cout << "\nTest: Normalization with Invalid Indexes on " << filename << "\n";
+
+        const auto& info = wav.mInfo;
+        assert(info.channels == expected_channels);
+
+        AudioSamples pAudio = wav.pAudio;
+        assert(pAudio);
+
+        // Invalid range: start after end
+        sample_pos start = info.length;
+        sample_pos end = info.length / 2;
+
+        auto params = NormalizationParams::create(start, end, errorHandler, 1.0f, NormalizationMode::RMS);
+        assert(!params && "Expected failure due to invalid range");
+
+        std::cout << "Handled invalid range without crashing.\n";
+        std::cout << "--------------------------------------------------\n";
+    }
+};

--- a/test/test.cc
+++ b/test/test.cc
@@ -8,6 +8,7 @@
 #include "gain/gain_tests.cc"
 #include "reverb/reverb_tests.cc"
 #include "fade/fade_tests.cc"
+#include "normalization/norm_tests.cc"
 
 int main() {
     // Show current working directory
@@ -16,7 +17,7 @@ int main() {
         std::cout << "Current working directory: " << cwd << std::endl;
     }
 
-    // // Run MP3 file tests
+    // Run MP3 file tests
     // MP3FileTests::run_all();
 
     // // Run WAV file tests
@@ -31,9 +32,11 @@ int main() {
     // // Run Reverb Tests
     // ReverbTests::run_all();
 
-    // Run Fade Tests
-    FadeTests::run_all();
+    // // Run Fade Tests
+    // FadeTests::run_all();
 
+    // Run Normalization Tests
+    NormalizationTests::run_all();
 
 
     


### PR DESCRIPTION
- Implemented Peak and RMS normalization methods
- Added AVX and naive gain application paths for Peak mode
- Introduced NormalizationParams with target, mode, and gain settings
- Included basic peak limiter in RMS normalization to prevent excessive gain
- Documented header and methods with Doxygen comments
- Added warning that RMS mode is experimental and Peak is recommended