### PR TITLE
Refactor DSP parameter classes to use Params structs and PrivateTag c…

### DIFF
--- a/include/core/effect_params.h
+++ b/include/core/effect_params.h
@@ -12,14 +12,34 @@ namespace AJ::dsp {
  * which the effect should be applied to.
  */
 class EffectParams {
-public:
-    virtual ~EffectParams() = default;
-
+private:
     /// @brief Start position of the effect in samples.
     sample_pos mStart;
 
     /// @brief End position (included) of the effect in samples.
     sample_pos mEnd;
+public:
+    virtual ~EffectParams() = default;
+
+    /// @brief Set the start position of the effect in samples.
+    void setStart(sample_pos start) { 
+        mStart = start; 
+    }
+
+    /// @brief Get the start position of the effect in samples.
+    sample_pos Start() const { 
+        return mStart; 
+    }
+
+    /// @brief Set the end position (inclusive) of the effect in samples.
+    void setEnd(sample_pos end) { 
+        mEnd = end; 
+    }
+
+    /// @brief Get the end position (inclusive) of the effect in samples.
+    sample_pos End() const { 
+        return mEnd; 
+    }
 };
 
 }

--- a/include/dsp/distortion.h
+++ b/include/dsp/distortion.h
@@ -1,11 +1,23 @@
-// #pragma once
-// #include "effect.h"
+#pragma once
+#include "effect.h"
 
 
-// namespace AJ::dsp {
-//     class Distortion : public AJ::dsp::Effect {
-//     public:
-//         void process(AudioBuffer &buffer, sample_pos start, sample_pos end, short chan) override;
+namespace AJ::dsp {
+class Distortion : public AJ::dsp::Effect {
 
-//     };
-// };
+// planning to add more distortion types.
+enum DistortionType {
+    SoftClipping
+};
+
+class DistortionParams : public EffectParams {
+    
+};
+
+
+public:
+
+    bool process(Float &buffer, AJ::error::IErrorHandler &handler) override;
+
+};
+};

--- a/include/dsp/fade.h
+++ b/include/dsp/fade.h
@@ -6,8 +6,7 @@
 #include "core/effect_params.h"
 #include "core/error_handler.h"
 
-namespace AJ::dsp {
-
+namespace AJ::dsp::fade {
 /**
  * @brief Fade direction options.
  * 
@@ -18,6 +17,20 @@ enum FadeMode {
     In,  ///< Fade in
     Out  ///< Fade out
 };
+
+/**
+ * @brief Container for all fade effect parameters.
+ * 
+ * This structure holds the configuration required to apply a fade-in or fade-out effect.
+ */
+struct Params {
+    sample_pos mStart;   /**< Sample position where the fade starts (inclusive). */
+    sample_pos mEnd;     /**< Sample position where the fade ends (inclusive). */
+    float mHighGain;     /**< Gain at the louder phase of the fade (clamped to [0.0f, 2.0f]). */
+    float mLowGain;      /**< Gain at the quieter phase of the fade (clamped to [0.0f, 2.0f]). */
+    FadeMode mMode;      /**< Fade direction (FadeMode::In or FadeMode::Out). */
+};
+
 
 /**
  * @brief Parameters for the Fade effect.
@@ -40,21 +53,23 @@ public:
     /**
      * @brief Factory method to create a FadeParams instance.
      * 
-     * Validates and constructs parameters for a fade effect. 
+     * Constructs and validates a FadeParams object using values provided in a Params structure.
+     * 
+     * Validation rules:
      * - `highGain` must be greater than `lowGain`.
      * - Gains are clamped to the range [0.0f, 2.0f].
      * 
-     * @param start     Sample position where the fade starts.
-     * @param end       Sample position where the fade ends (inclusive).
-     * @param highGain  Gain at the louder phase of the fade (clamped to [0.0f, 2.0f]).
-     * @param lowGain   Gain at the quieter phase of the fade (clamped to [0.0f, 2.0f]).
-     * @param mode      Fade direction (FadeMode::In or FadeMode::Out).
-     * @param handler   Error handler for parameter validation failures.
+     * The constructor is intentionally restricted — use this method as the only way
+     * to create a FadeParams instance.
      * 
-     * @return Shared pointer to a valid FadeParams instance, or nullptr if parameters are invalid.
+     * @param params   Struct containing all fade effect parameters.
+     * @param handler  Error handler for reporting parameter validation failures.
+     * 
+     * @return Shared pointer to a valid FadeParams instance if parameters are valid,
+     *         otherwise nullptr.
      */
-    static std::shared_ptr<FadeParams> create(sample_pos& start, sample_pos& end,
-        float& highGain, float& lowGain, FadeMode& mode, AJ::error::IErrorHandler &handler);
+    static std::shared_ptr<FadeParams> create(Params &params, AJ::error::IErrorHandler &handler);
+
 
     /// @return Gain at the loud end of the fade.
     float highGain() { return mHighGain; }
@@ -98,8 +113,8 @@ public:
     FadeParams(PrivateTag) {
         mHighGain = 1.0f;
         mLowGain = 0.0f;
-        mStart = 0;
-        mEnd = 0;
+        setStart(0);
+        setEnd(-1);
         mMode = FadeMode::In;
     }
 };

--- a/include/dsp/normalization.h
+++ b/include/dsp/normalization.h
@@ -6,9 +6,9 @@
 
 #include "effect.h"
 #include "core/effect_params.h"
+#include "core/types.h"
 
-namespace AJ::dsp {
-
+namespace AJ::dsp::normalization {
 /**
  * @brief Modes of normalization.
  *
@@ -21,6 +21,31 @@ namespace AJ::dsp {
 enum NormalizationMode {
     Peak,  ///< Peak normalization mode.
     RMS,   ///< RMS normalization mode.
+};
+
+/**
+ * @brief Container for all normalization effect parameters.
+ * 
+ * Holds the configuration needed to normalize an audio segment.
+ */
+struct Params {
+    sample_pos mStart;   /**< Sample position where normalization starts (inclusive). */
+    sample_pos mEnd;     /**< Sample position where normalization ends (inclusive). */
+    float mTarget;       /**< Target normalization level (default: 1.0f). */
+    NormalizationMode mMode; /**< Normalization mode (default: NormalizationMode::Peak). */
+
+    /**
+     * @brief Construct a Params object with default normalization values.
+     * 
+     * By default:
+     * - `mTarget` is set to 1.0f.
+     * - `mMode` is set to NormalizationMode::Peak.
+     */
+    Params()
+        : mStart(0)
+        , mEnd(0)
+        , mTarget(1.0f)
+        , mMode(NormalizationMode::Peak) {}
 };
 
 /**
@@ -40,19 +65,23 @@ public:
     /**
      * @brief Factory method to create a NormalizationParams instance.
      * 
-     * Validates and constructs parameters for a Normalization effect. 
+     * Constructs and validates a NormalizationParams object using values provided 
+     * in a Params structure.
      * 
-     * @param start     Sample position where normalization starts.
-     * @param end       Sample position where normalization ends (inclusive).
-     * @param handler   Error handler for parameter validation failures.
-     * @param target    Normalization target (linear, not dBFS) in range [0.0f, 1.0f]. Default = 1.0f.
-     * @param mode      Normalization mode (NormalizationMode::Peak or NormalizationMode::RMS). Default = Peak.
+     * Validation rules:
+     * - `target` must be non-negative.
      * 
-     * @return Shared pointer to a valid NormalizationParams instance, or nullptr if parameters are invalid.
+     * The constructor is intentionally restricted — use this method as the only way
+     * to create a NormalizationParams instance.
+     * 
+     * @param params   Struct containing all normalization effect parameters.
+     * @param handler  Error handler for reporting parameter validation failures.
+     * 
+     * @return Shared pointer to a valid NormalizationParams instance if parameters are valid,
+     *         otherwise nullptr.
      */
-    static std::shared_ptr<NormalizationParams> create(sample_pos& start, sample_pos& end,
-        AJ::error::IErrorHandler &handler, float target = 1.0f,
-        NormalizationMode mode = NormalizationMode::Peak);
+    static std::shared_ptr<NormalizationParams> create(Params &params, AJ::error::IErrorHandler &handler);
+
 
     /// @return The current target amplitude (linear).
     float Target(){

--- a/include/dsp/reverb/reverb.h
+++ b/include/dsp/reverb/reverb.h
@@ -12,39 +12,140 @@
 namespace AJ::dsp::reverb {
 
 /**
- * @brief Parameters used for configuring the Reverb effect.
+ * @brief Simple struct holding raw reverb configuration values.
+ *        must set all values for initializing reverb effect.
  */
-class ReverbParams : public EffectParams {
-public:
+struct Params {
     float mDelayMS;       /**< Delay time in milliseconds. */
     float mWetMix;        /**< Volume of the wet (processed) signal. */
     float mDryMix;        /**< Volume of the dry (original) signal. */
     int mSamplerate;      /**< Sampling rate of the audio in Hz. */
     float mGain;          /**< Feedback gain for reverb intensity. */
 
+    sample_c mStart;      /**< Sample position where reverb starts. */
+    sample_c mEnd;        /**< Sample position where reverb ends (inclusive). */
+};
+
+/**
+ * @brief Parameters used for configuring the Reverb effect.
+ */
+class ReverbParams : public EffectParams {
+    struct PrivateTag {}; /**< Internal tag for controlled construction. */
+
+    float mDelayMS;       /**< Delay time in milliseconds. */
+    float mWetMix;        /**< Volume of the wet (processed) signal. */
+    float mDryMix;        /**< Volume of the dry (original) signal. */
+    int mSamplerate;      /**< Sampling rate of the audio in Hz. */
+    float mGain;          /**< Feedback gain for reverb intensity. */
+
+public:
+
+    /**
+     * @brief Factory method to create a ReverbParams instance.
+     * 
+     * Validates and constructs parameters for a Reverb effect. 
+     * This is the only intended way to create an instance of ReverbParams,
+     * because although the constructor is technically public, it requires a
+     * special PrivateTag parameter that cannot be accessed outside this class.
+     * This pattern enforces controlled initialization while keeping the API clean.
+     * 
+     * @param params    Struct containing all parameters.
+     * @param handler   Error handler for parameter validation failures.
+     * @return Shared pointer to a valid ReverbParams instance, or nullptr if parameters are invalid.
+     */
+    static std::shared_ptr<ReverbParams> create(Params &params, AJ::error::IErrorHandler &handler);
+
+    /**
+     * @brief Sets the delay time in milliseconds.
+     * @param delayMS New delay time.
+     */
+    void setDelayMS(float delayMS) {
+        mDelayMS = std::clamp(delayMS,
+            static_cast<float>(REVERB_DELAY_MIN),
+            static_cast<float>(REVERB_DELAY_MAX));
+    }
+
+    /**
+     * @brief Sets the wet mix (processed signal level).
+     * @param wetMix New wet mix value.
+     */
+    void setWetMix(float wetMix) {
+        mWetMix = std::clamp(wetMix,
+            static_cast<float>(REVERB_MIX_MIN),
+            static_cast<float>(REVERB_MIX_MAX));
+    }
+
+    /**
+     * @brief Sets the dry mix (original signal level).
+     * @param dryMix New dry mix value.
+     */
+    void setDryMix(float dryMix) {
+        mDryMix = std::clamp(dryMix,
+            static_cast<float>(REVERB_MIX_MIN),
+            static_cast<float>(REVERB_MIX_MAX));
+    }
+
+    /**
+     * @brief Sets the audio sample rate.
+     * init the all pass filters.
+     * 
+     * @param samplerate New sample rate in Hz.
+     */
+    void setSamplerate(int samplerate) {
+        mSamplerate = samplerate;
+    }
+
+    /**
+     * @brief Sets the reverb feedback gain.
+     * @param gain New gain value.
+     */
+    void setGain(float gain) {
+        mGain = std::clamp(gain, REVERB_GAIN_MIN, REVERB_GAIN_MAX);
+    }
+
+    /**
+     * @brief Returns the delay time in milliseconds.
+     */
+    float DelayMS() const { return mDelayMS; }
+
+    /**
+     * @brief Returns the wet mix value.
+     */
+    float WetMix() const { return mWetMix; }
+
+    /**
+     * @brief Returns the dry mix value.
+     */
+    float DryMix() const { return mDryMix; }
+
+    /**
+     * @brief Returns the feedback gain.
+     */
+    float Gain() const { return mGain; }
+
+    /**
+     * @brief Returns the sample rate in Hz.
+     */
+    int Samplerate() const { return mSamplerate; }
+
+    /**
+     * @brief Destructor.
+     */
     ~ReverbParams() override = default;
 
     /**
-     * @brief Default constructor with unset range.
+     * @brief Default constructor with unset start/end range.
      */
-    ReverbParams() {
-        mStart = -1;
-        mEnd = -1;
-    }
-
-    /**
-     * @brief Constructor with start and end sample positions.
-     * 
-     * @param start Start sample index.
-     * @param end End sample index.
-     */
-    ReverbParams(sample_pos start, sample_pos end) {
-        mStart = start;
-        mEnd = end;
+    ReverbParams(PrivateTag) {
+        setStart(-1);
+        setEnd(-1);
     }
 };
 
+/// Type alias for the comb filter array used in the reverb.
 using CombFilters = std::array<std::unique_ptr<CombFilter>, kCombFilters>;
+
+/// Type alias for the all-pass filter array used in the reverb.
 using AllPassFilters = std::array<std::unique_ptr<AllPassFilter>, kAllPassFilters>;
 
 /**
@@ -52,17 +153,7 @@ using AllPassFilters = std::array<std::unique_ptr<AllPassFilter>, kAllPassFilter
  * 
  * Adds reverberation (echo-like reflections) to audio using a combination of comb and all-pass filters.
  * Supports adjustable parameters such as delay, gain, dry/wet mix.
- * 
- * TODO: Add support for different reverb presets (e.g., room, hall, cathedral).
- * 
- * Example presets:
- * | Reverb Type | Delay (ms) | Wet Mix | Dry Mix | Gain |
- * |-------------|------------|---------|---------|------|
- * | Room        | 25.0       | 0.3     | 0.7     | 0.4  |
- * | Hall        | 70.0       | 0.5     | 0.5     | 0.7  |
- * | Cathedral   | 110.0      | 0.8     | 0.2     | 0.9  |
  */
-
 class Reverb : public AJ::dsp::Effect {
 
 private:
@@ -71,7 +162,12 @@ private:
     AllPassFilters mAllPassFilters;            /**< Array of all-pass filters used to smooth echo tails. */
 
     /**
-     * @brief Validates the processing range.
+     * @brief Validates the processing range indexes.
+     * 
+     * @param buffer Audio buffer to check.
+     * @param handler Error handler for reporting invalid indexes.
+     * 
+     * @return true if indexes are valid.
      */
     bool checkValidIndxes(Float &buffer, AJ::error::IErrorHandler &handler);
 
@@ -79,88 +175,53 @@ public:
     /**
      * @brief Default constructor initializing filters and default parameters.
      */
-    Reverb() {
-        mParams = std::make_shared<ReverbParams>();
-
-        mParams->mGain = REVERB_GAIN;
-        mParams->mDelayMS = REVERB_DELAY;
-        mParams->mDryMix = REVERB_DRY_MIX;
-        mParams->mWetMix = REVERB_WET_MIX;
+    Reverb(){
+        mParams = nullptr;
 
         for (auto &comb : mCombFilters) {
             comb = std::make_unique<CombFilter>();
-        }
-
-        for (auto &all_pass : mAllPassFilters) {
-            all_pass = std::make_unique<AllPassFilter>(mParams->mSamplerate);
-        }
-    }
-
-    /**
-     * @brief Constructor with sample rate.
-     * 
-     * @param samplerate Sample rate of the audio in Hz.
-     */
-    Reverb(int samplerate) {
-        mParams = std::make_shared<ReverbParams>();
-        mParams->mSamplerate = samplerate;
-        mParams->mGain = REVERB_GAIN;
-        mParams->mDelayMS = REVERB_DELAY;
-        mParams->mDryMix = REVERB_DRY_MIX;
-        mParams->mWetMix = REVERB_WET_MIX;
-
-        for (auto &comb : mCombFilters) {
-            comb = std::make_unique<CombFilter>();
-        }
-
-        for (auto &all_pass : mAllPassFilters) {
-            all_pass = std::make_unique<AllPassFilter>(mParams->mSamplerate);
         }
     }
 
     /**
      * @brief Sets the reverb delay time in milliseconds.
+     * @param val New delay time in ms.
      */
-    void setDelay(float delayMS) {
-        mParams->mDelayMS = std::clamp(delayMS,
-            static_cast<float>(REVERB_DELAY_MIN),
-            static_cast<float>(REVERB_DELAY_MAX));
-    }
+    void setDelayMS(float val) { mParams->setDelayMS(val); }
 
     /**
      * @brief Sets the dry signal mix (original audio).
+     * @param val New dry mix value.
      */
-    void setDryMix(float mix) {
-        mParams->mDryMix = std::clamp(mix,
-            static_cast<float>(REVERB_MIX_MIN),
-            static_cast<float>(REVERB_MIX_MAX));
-    }
+    void setDryMix(float val) { mParams->setDryMix(val); }
 
     /**
      * @brief Sets the wet signal mix (processed audio).
+     * @param val New wet mix value.
      */
-    void setWetMix(float mix) {
-        mParams->mWetMix = std::clamp(mix,
-            static_cast<float>(REVERB_MIX_MIN),
-            static_cast<float>(REVERB_MIX_MAX));
-    }
+    void setWetMix(float val) { mParams->setWetMix(val); }
 
     /**
      * @brief Sets the reverb gain (feedback strength).
+     * @param val New gain value.
      */
-    void setGain(float gain) {
-        mParams->mGain = std::clamp(gain, REVERB_GAIN_MIN, REVERB_GAIN_MAX);
-    }
+    void setGain(float val) { mParams->setGain(val); }
 
     /**
      * @brief Sets the audio sample rate.
+     * @param val New sample rate in Hz.
      */
-    void setSamplerate(int samplerate) {
-        mParams->mSamplerate = samplerate;
+    void setSamplerate(int val) { 
+        mParams->setSamplerate(val); 
+
+        for (auto &all_pass : mAllPassFilters) {
+            all_pass = std::make_unique<AllPassFilter>(mParams->Samplerate());
+        }
     }
 
     /**
      * @brief Sets effect parameters using a shared EffectParams pointer.
+     * must be called before process()
      * 
      * @param params A polymorphic pointer to effect parameters.
      * @param handler Error handler for reporting issues.
@@ -171,26 +232,58 @@ public:
 
     /**
      * @brief Defines the range of samples to process.
-     * 
      * @param start Start sample index (inclusive).
      * @param end End sample index (inclusive).
      */
     void setRange(sample_pos start, sample_pos end) {
         if (start <= end) {
-            mParams->mStart = start;
-            mParams->mEnd = end;
+            mParams->setStart(start);
+            mParams->setEnd(end);
         }
     }
+    
+    /**
+     * @brief Gets the current reverb delay in ms.
+     */
+    float DelayMS() const { return mParams->DelayMS(); }
 
     /**
+     * @brief Gets the current wet mix.
+     */
+    float WetMix() const { return mParams->WetMix(); }
+
+    /**
+     * @brief Gets the current dry mix.
+     */
+    float DryMix() const { return mParams->DryMix(); }
+
+    /**
+     * @brief Gets the current sample rate in Hz.
+     */
+    int Samplerate() const { return mParams->Samplerate(); }
+
+    /**
+     * @brief Gets the current reverb gain.
+     */
+    float Gain() const { return mParams->Gain(); }
+
+    /**
+     * @brief Gets the start sample index for processing.
+     */
+    sample_pos Start() const { return mParams->Start(); }
+
+    /**
+     * @brief Gets the end sample index for processing.
+     */
+    sample_pos End() const { return mParams->End(); }
+    
+    /**
      * @brief Processes the audio buffer with reverb.
-     * 
      * @param buffer Audio buffer to modify.
      * @param handler Error handler for reporting runtime issues.
-     * 
      * @return true if processing succeeded.
      */
     bool process(Float &buffer, AJ::error::IErrorHandler &handler) override;
 };
 
-};
+}; // namespace AJ::dsp::reverb

--- a/src/core/aj_audio_engine.cc
+++ b/src/core/aj_audio_engine.cc
@@ -76,12 +76,12 @@ bool AJ::AJ_Engine::applyEffect(Float &buffer,
     switch (effect)
     {
         case Effect::gain: {
-            audioEffect = std::make_shared<AJ::dsp::Gain>();
+            audioEffect = std::make_shared<AJ::dsp::gain::Gain>();
             break;
         }
 
         case Effect::echo: {
-            audioEffect = std::make_shared<AJ::dsp::Echo>();
+            audioEffect = std::make_shared<AJ::dsp::echo::Echo>();
             break;
         }
 

--- a/src/dsp/echo/echo.cc
+++ b/src/dsp/echo/echo.cc
@@ -6,7 +6,28 @@
 #include "core/types.h"
 #include "core/error_handler.h"
 
-bool AJ::dsp::Echo::process(Float &buffer, AJ::error::IErrorHandler &handler) {
+std::shared_ptr<AJ::dsp::echo::EchoParams> AJ::dsp::echo::EchoParams::create(Params& params,
+    AJ::error::IErrorHandler &handler) {
+    std::shared_ptr<EchoParams> echoParams = std::make_shared<EchoParams>(PrivateTag{});
+    
+    sample_c delaySamples = params.mDelayInSeconds * params.mSamplerate;
+
+    if(params.mStart > params.mEnd || params.mStart < 0 || params.mStart + delaySamples >= params.mEnd) {
+        const std::string message = "invalid range indexes parameters for echo effect.\n";
+        handler.onError(error::Error::InvalidEffectParameters, message);
+
+        return nullptr;
+    }
+
+    echoParams->setDecay(params.mDecay);
+    echoParams->setDelaySamples(delaySamples);
+    echoParams->setStart(params.mStart);
+    echoParams->setEnd(params.mEnd);
+
+    return echoParams;
+}
+
+bool AJ::dsp::echo::Echo::process(Float &buffer, AJ::error::IErrorHandler &handler) {
 #if defined(__AVX__)
     if (__builtin_cpu_supports("avx")) {
         return echoSIMD_AVX(buffer, handler);
@@ -22,7 +43,7 @@ bool AJ::dsp::Echo::process(Float &buffer, AJ::error::IErrorHandler &handler) {
     return echoNaive(buffer, handler);
 }
 
-AJ::sample_t AJ::dsp::Echo::calculate_new_sample_with_echo(Float &in, sample_pos sample_idx, sample_pos echo_idx,  AJ::error::IErrorHandler &handler){
+AJ::sample_t AJ::dsp::echo::Echo::calculate_new_sample_with_echo(Float &in, sample_pos sample_idx, sample_pos echo_idx,  AJ::error::IErrorHandler &handler){
     if(sample_idx >= in.size() || sample_idx < 0){
         const std::string message = "Invalid Index: sample_idx is not in a valid range.\n";
         handler.onError(error::Error::InternalError, message);
@@ -36,7 +57,7 @@ AJ::sample_t AJ::dsp::Echo::calculate_new_sample_with_echo(Float &in, sample_pos
         return 0.0f;
     }
 
-    sample_t newSample = in[sample_idx] + (in[echo_idx] * mParams->mDecay);
+    sample_t newSample = in[sample_idx] + (in[echo_idx] * mParams->Decay());
 
     if(newSample > 1.0f) newSample = 1.0f;
     else if (newSample < -1.0f) newSample = -1.0f;
@@ -44,11 +65,11 @@ AJ::sample_t AJ::dsp::Echo::calculate_new_sample_with_echo(Float &in, sample_pos
     return newSample;
 }
 
-void AJ::dsp::Echo::SetDelaySamples(decay_t delayInSeconds, sample_c sampleRate){
-    mParams->mDelaySamples = sampleRate * delayInSeconds;
+void AJ::dsp::echo::Echo::SetDelaySamples(decay_t delayInSeconds, sample_c sampleRate){
+    mParams->setDelaySamples(sampleRate * delayInSeconds);
 }
 
-bool AJ::dsp::Echo::setParams(std::shared_ptr<EffectParams> params, AJ::error::IErrorHandler &handler){
+bool AJ::dsp::echo::Echo::setParams(std::shared_ptr<EffectParams> params, AJ::error::IErrorHandler &handler){
     std::shared_ptr<EchoParams> echoParams = std::dynamic_pointer_cast<EchoParams>(params);
     // if echoParams is nullptr that means it's not a shared_ptr of EchoParams
     if(!echoParams){
@@ -61,18 +82,18 @@ bool AJ::dsp::Echo::setParams(std::shared_ptr<EffectParams> params, AJ::error::I
     return true;
 }
 
-bool AJ::dsp::Echo::echoNaive(Float &buffer, AJ::error::IErrorHandler &handler){
+bool AJ::dsp::echo::Echo::echoNaive(Float &buffer, AJ::error::IErrorHandler &handler){
     /*
         ?Echo Effect Equation:
-            Echo_Sample = in[i - _mDelaySamples] * _mDecay
+            Echo_Sample = in[i - _DelaySamples()] * _mDecay
             out[i] = in[i] + Echo_Sample
 
         ! we must avoid writing at the input buffer to avoid speculative samples.
     */
 
     // check valid indexes ranges
-    if(mParams->mEnd < mParams->mStart || mParams->mStart < 0 ||
-         mParams->mStart + mParams->mDelaySamples >= buffer.size() || mParams->mEnd >= buffer.size()){
+    if(mParams->End() < mParams->Start() || mParams->Start() < 0 ||
+         mParams->Start() + mParams->DelaySamples() >= buffer.size() || mParams->End() >= buffer.size()){
         const std::string message = "invalid indexes for echo effect.\n";
         handler.onError(error::Error::InvalidEffectParameters, message);
 
@@ -81,16 +102,16 @@ bool AJ::dsp::Echo::echoNaive(Float &buffer, AJ::error::IErrorHandler &handler){
 
     Float out;
     //* copy the first samples
-    out.resize(mParams->mEnd - mParams->mStart + 1, 0.0f);
-    std::copy(buffer.begin() + mParams->mStart, buffer.begin() + mParams->mStart + mParams->mDelaySamples, out.begin());
+    out.resize(mParams->End() - mParams->Start() + 1, 0.0f);
+    std::copy(buffer.begin() + mParams->Start(), buffer.begin() + mParams->Start() + mParams->DelaySamples(), out.begin());
 
-    for(sample_pos i = mParams->mStart + mParams->mDelaySamples; i <= mParams->mEnd; ++i){
-        sample_t sample = calculate_new_sample_with_echo(buffer, i, i - mParams->mDelaySamples, handler);
-        out[i - mParams->mStart] = sample;
+    for(sample_pos i = mParams->Start() + mParams->DelaySamples(); i <= mParams->End(); ++i){
+        sample_t sample = calculate_new_sample_with_echo(buffer, i, i - mParams->DelaySamples(), handler);
+        out[i - mParams->Start()] = sample;
     }
 
     //* copy the new samples into the main buffer
-    std::copy(out.begin(), out.end(), buffer.begin() + mParams->mStart);
+    std::copy(out.begin(), out.end(), buffer.begin() + mParams->Start());
     return true;
 }
 

--- a/src/dsp/echo/echo_avx.cc
+++ b/src/dsp/echo/echo_avx.cc
@@ -11,10 +11,10 @@
 */
 
 
-bool AJ::dsp::Echo::echoSIMD_AVX(Float &buffer, AJ::error::IErrorHandler &handler){
+bool AJ::dsp::echo::Echo::echoSIMD_AVX(Float &buffer, AJ::error::IErrorHandler &handler){
     // check valid indexes ranges
-    if(mParams->mEnd < mParams->mStart || mParams->mStart < 0 || mParams->mStart + 
-        mParams->mDelaySamples >= buffer.size() || mParams->mEnd >= buffer.size()){
+    if(mParams->End() < mParams->Start() || mParams->Start() < 0 || mParams->Start() + 
+        mParams->DelaySamples() >= buffer.size() || mParams->End() >= buffer.size()){
         const std::string message = "invalid indexes for echo effect.\n";
         handler.onError(error::Error::InvalidEffectParameters, message);
         return false;
@@ -22,25 +22,25 @@ bool AJ::dsp::Echo::echoSIMD_AVX(Float &buffer, AJ::error::IErrorHandler &handle
 
     Float out;
     //* copy the first samples
-    out.resize(mParams->mEnd - mParams->mStart + 1, 0.0f);
-    std::copy(buffer.begin() + mParams->mStart, buffer.begin() + mParams->mStart + mParams->mDelaySamples, out.begin());
+    out.resize(mParams->End() - mParams->Start() + 1, 0.0f);
+    std::copy(buffer.begin() + mParams->Start(), buffer.begin() + mParams->Start() + mParams->DelaySamples(), out.begin());
 
     size_t i;
     // set SSE vector for decay value
-    __m256 decay_v = _mm256_set1_ps(mParams->mDecay);
+    __m256 decay_v = _mm256_set1_ps(mParams->Decay());
 
     // set max and min values for clamping
     __m256 max_val = _mm256_set1_ps(1.0f);
     __m256 min_val = _mm256_set1_ps(-1.0f);
 
-    for(i = mParams->mStart + mParams->mDelaySamples; i + 7 <= mParams->mEnd; i += 8){
+    for(i = mParams->Start() + mParams->DelaySamples(); i + 7 <= mParams->End(); i += 8){
         // load 8 current samples in SSE vector
         // load 8 delayed samples in SSE vector
         // echo_samples = delay_samples * decay_v
         // new_samples = echo_samples + samples
         __m256 new_samples = _mm256_add_ps(
             _mm256_mul_ps(
-                _mm256_loadu_ps(&buffer[i - mParams->mDelaySamples]), // 8 delayed samples
+                _mm256_loadu_ps(&buffer[i - mParams->DelaySamples()]), // 8 delayed samples
                 decay_v 
             ), // multiply delayed_samples by decay factor
             _mm256_loadu_ps(&buffer[i]) // 8 current samples
@@ -49,7 +49,7 @@ bool AJ::dsp::Echo::echoSIMD_AVX(Float &buffer, AJ::error::IErrorHandler &handle
         // clamping the calculated samples to make sure it's in valid range [-1.0, 1.0]
         // store the new 8 samples in the proper indexes of out vector 
         _mm256_storeu_ps(
-            &out[i - mParams->mStart],
+            &out[i - mParams->Start()],
              _mm256_max_ps (
                 _mm256_min_ps(new_samples, max_val),
                 min_val
@@ -58,11 +58,11 @@ bool AJ::dsp::Echo::echoSIMD_AVX(Float &buffer, AJ::error::IErrorHandler &handle
     }
 
     // calculate the rest if there.
-    for(i; i <= mParams->mEnd; ++i){
-        sample_t sample = calculate_new_sample_with_echo(buffer, i, i - mParams->mDelaySamples, handler);
-        out[i - mParams->mStart] = sample;
+    for(i; i <= mParams->End(); ++i){
+        sample_t sample = calculate_new_sample_with_echo(buffer, i, i - mParams->DelaySamples(), handler);
+        out[i - mParams->Start()] = sample;
     }
 
-    std::copy(out.begin(), out.end(), buffer.begin() + mParams->mStart);
+    std::copy(out.begin(), out.end(), buffer.begin() + mParams->Start());
     return true;
 }

--- a/src/dsp/echo/echo_sse.cc
+++ b/src/dsp/echo/echo_sse.cc
@@ -7,10 +7,10 @@
 // SIMD Headers:
 #include <xmmintrin.h> // SSE (Streaming SIMD Extensions) - 128-bit operations on 4 floats
 
-bool AJ::dsp::Echo::echoSIMD_SSE(Float &buffer, AJ::error::IErrorHandler &handler){
+bool AJ::dsp::echo::Echo::echoSIMD_SSE(Float &buffer, AJ::error::IErrorHandler &handler){
     // check valid indexes ranges
-    if(mParams->mEnd < mParams->mStart || mParams->mStart < 0 ||
-        mParams->mStart + mParams->mDelaySamples >= buffer.size() || mParams->mEnd >= buffer.size()){
+    if(mParams->End() < mParams->Start() || mParams->Start() < 0 ||
+        mParams->Start() + mParams->DelaySamples() >= buffer.size() || mParams->End() >= buffer.size()){
         const std::string message = "invalid indexes for echo effect.\n";
         handler.onError(error::Error::InvalidEffectParameters, message);
         return false;
@@ -18,26 +18,26 @@ bool AJ::dsp::Echo::echoSIMD_SSE(Float &buffer, AJ::error::IErrorHandler &handle
 
     Float out;
     //* copy the first samples
-    out.resize(mParams->mEnd - mParams->mStart + 1, 0.0f);
-    std::copy(buffer.begin() + mParams->mStart,
-        buffer.begin() + mParams->mStart + mParams->mDelaySamples, out.begin());
+    out.resize(mParams->End() - mParams->Start() + 1, 0.0f);
+    std::copy(buffer.begin() + mParams->Start(),
+        buffer.begin() + mParams->Start() + mParams->DelaySamples(), out.begin());
 
     size_t i;
     // set SSE vector for decay value
-    __m128 decay_v = _mm_set1_ps(mParams->mDecay);
+    __m128 decay_v = _mm_set1_ps(mParams->Decay());
 
     // set max and min values for clamping
     __m128 max_val = _mm_set1_ps(1.0f);
     __m128 min_val = _mm_set1_ps(-1.0f);
 
-    for(i = mParams->mStart + mParams->mDelaySamples; i + 3 <= mParams->mEnd; i += 4){
+    for(i = mParams->Start() + mParams->DelaySamples(); i + 3 <= mParams->End(); i += 4){
         // load 4 current samples in SSE vector
         // load 4 delayed samples in SSE vector
         // echo_samples = delay_samples * decay_v
         // new_samples = echo_samples + samples
         __m128 new_samples = _mm_add_ps(
             _mm_mul_ps(
-                _mm_load_ps(&buffer[i - mParams->mDelaySamples]), // 4 delayed samples
+                _mm_load_ps(&buffer[i - mParams->DelaySamples()]), // 4 delayed samples
                 decay_v 
             ), // multiply delayed_samples by decay factor
             _mm_load_ps(&buffer[i]) // 4 current samples
@@ -46,7 +46,7 @@ bool AJ::dsp::Echo::echoSIMD_SSE(Float &buffer, AJ::error::IErrorHandler &handle
         // clamping the calculated samples to make sure it's in valid range [-1.0, 1.0]
         // store the new 4 samples in the proper indexes of out vector 
         _mm_store_ps(
-            &out[i - mParams->mStart],
+            &out[i - mParams->Start()],
              _mm_max_ps (
                 _mm_min_ps(new_samples, max_val),
                 min_val
@@ -55,12 +55,12 @@ bool AJ::dsp::Echo::echoSIMD_SSE(Float &buffer, AJ::error::IErrorHandler &handle
     }
 
     // calculate the rest if there.
-    for(i; i <= mParams->mEnd; ++i){
-        sample_t sample = calculate_new_sample_with_echo(buffer, i, i - mParams->mDelaySamples, handler);
-        out[i - mParams->mStart] = sample;
+    for(i; i <= mParams->End(); ++i){
+        sample_t sample = calculate_new_sample_with_echo(buffer, i, i - mParams->DelaySamples(), handler);
+        out[i - mParams->Start()] = sample;
     }
 
-    std::copy(out.begin(), out.end(), buffer.begin() + mParams->mStart);
+    std::copy(out.begin(), out.end(), buffer.begin() + mParams->Start());
     return true;
 }
 

--- a/src/dsp/fade/fade_avx.cc
+++ b/src/dsp/fade/fade_avx.cc
@@ -9,9 +9,9 @@
     - AVX (Advanced Vector Extensions) - 256-bit operations (8 floats)
 */
 
-bool AJ::dsp::Fade::fadeAVX(Float &buffer, AJ::error::IErrorHandler &handler){
+bool AJ::dsp::fade::Fade::fadeAVX(Float &buffer, AJ::error::IErrorHandler &handler){
     // check valid indexes ranges
-    if(mParams->mEnd < mParams->mStart || mParams->mStart < 0 || mParams->mEnd >= buffer.size()){
+    if(mParams->End() < mParams->Start() || mParams->Start() < 0 || mParams->End() >= buffer.size()){
         const std::string message = "invalid indexes for fade effect.\n";
         handler.onError(error::Error::InvalidEffectParameters, message);
 
@@ -21,7 +21,7 @@ bool AJ::dsp::Fade::fadeAVX(Float &buffer, AJ::error::IErrorHandler &handler){
     float currentGain;
 
     float gainDiff = mParams->highGain() - mParams->lowGain();
-    sample_c totalSamples = mParams->mEnd - mParams->mStart + 1;
+    sample_c totalSamples = mParams->End() - mParams->Start() + 1;
     double gainStep = gainDiff / totalSamples;
 
     if(mParams->mode() == FadeMode::In){
@@ -49,7 +49,7 @@ bool AJ::dsp::Fade::fadeAVX(Float &buffer, AJ::error::IErrorHandler &handler){
     __m256 steps = _mm256_setr_ps(0, 1, 2, 3, 4, 5, 6, 7);
 
     sample_pos i;
-    for(i = mParams->mStart; i + 7 <= mParams->mEnd; i += 8){
+    for(i = mParams->Start(); i + 7 <= mParams->End(); i += 8){
         // get the current gain per sample.
         __m256 gain = _mm256_add_ps(
             _mm256_set1_ps(currentGain),
@@ -75,7 +75,7 @@ bool AJ::dsp::Fade::fadeAVX(Float &buffer, AJ::error::IErrorHandler &handler){
     }
 
     // calculate the rest if there.
-    for(i; i <= mParams->mEnd; ++i){
+    for(i; i <= mParams->End(); ++i){
         buffer[i] = std::clamp(buffer[i] * currentGain, -1.0f, 1.0f);
     }
 

--- a/src/dsp/gain/gain.cc
+++ b/src/dsp/gain/gain.cc
@@ -1,12 +1,38 @@
 #include <iostream>
 #include <memory>
 #include "core/types.h"
+#include "core/errors.h"
 
 #include "dsp/effect.h"
 #include "dsp/gain.h"
 #include "core/effect_params.h"
 
-bool AJ::dsp::Gain::setParams(std::shared_ptr<EffectParams> params, AJ::error::IErrorHandler &handler) {
+std::shared_ptr<AJ::dsp::gain::GainParams> AJ::dsp::gain::GainParams::create(Params& params, AJ::error::IErrorHandler &handler){
+    
+    std::shared_ptr<GainParams> gainParams = std::make_shared<GainParams>(PrivateTag{});
+        
+    if(params.mStart > params.mEnd || params.mStart < 0) {
+        const std::string message = "invalid range indexes parameters for gain effect.\n";
+        handler.onError(error::Error::InvalidEffectParameters, message);
+
+        return nullptr;
+    }
+
+    if(params.mGain < 0.0f || params.mGain > 5.0f){
+        const std::string message = "invalid gain value for gain effect, gain must be in range [0.0f, 5.0f].\n";
+        handler.onError(error::Error::InvalidEffectParameters, message);
+
+        return nullptr;
+    }
+
+    gainParams->setGain(params.mGain);
+    gainParams->setStart(params.mStart);
+    gainParams->setEnd(params.mEnd);
+
+    return gainParams;
+}
+
+bool AJ::dsp::gain::Gain::setParams(std::shared_ptr<EffectParams> params, AJ::error::IErrorHandler &handler) {
     std::shared_ptr<GainParams> gainParams = std::dynamic_pointer_cast<GainParams>(params);
     // if gainParams is nullptr that means it's not a shared_ptr of GainParams
     if(!gainParams){
@@ -19,9 +45,9 @@ bool AJ::dsp::Gain::setParams(std::shared_ptr<EffectParams> params, AJ::error::I
     return true;
 }
 
-bool AJ::dsp::Gain::process(Float &buffer, AJ::error::IErrorHandler &handler){
+bool AJ::dsp::gain::Gain::process(Float &buffer, AJ::error::IErrorHandler &handler){
 
-    if(mParams->mGain == 1.0) return false;
+    if(mParams->Gain() == 1.0) return false;
 
 #if defined(__AVX__)
     if (__builtin_cpu_supports("avx")) {
@@ -32,8 +58,8 @@ bool AJ::dsp::Gain::process(Float &buffer, AJ::error::IErrorHandler &handler){
     return gainNaive(buffer, handler);
 }
 
-void AJ::dsp::Gain::calculate_gain_sample(sample_t &sample){
-    sample *= mParams->mGain;
+void AJ::dsp::gain::Gain::calculate_gain_sample(sample_t &sample){
+    sample *= mParams->Gain();
 
     if(sample < -1.0){
         sample = -1.0;
@@ -44,16 +70,16 @@ void AJ::dsp::Gain::calculate_gain_sample(sample_t &sample){
     }
 }
 
-bool AJ::dsp::Gain::gainNaive(Float &buffer, AJ::error::IErrorHandler &handler){
+bool AJ::dsp::gain::Gain::gainNaive(Float &buffer, AJ::error::IErrorHandler &handler){
     // check valid indexes ranges
-    if(mParams->mEnd < mParams->mStart || mParams->mStart < 0 || 
-        mParams->mStart >= buffer.size() || mParams->mEnd >= buffer.size()){
+    if(mParams->End() < mParams->Start() || mParams->Start() < 0 || 
+        mParams->Start() >= buffer.size() || mParams->End() >= buffer.size()){
         const std::string message = "invalid indexes for gain effect.";
         handler.onError(error::Error::InvalidEffectParameters, message);
         return false;
     }
 
-    for(sample_pos i = mParams->mStart; i <= mParams->mEnd; ++i){
+    for(sample_pos i = mParams->Start(); i <= mParams->End(); ++i){
         calculate_gain_sample(buffer[i]);
     }
 

--- a/src/dsp/gain/gain_avx.cc
+++ b/src/dsp/gain/gain_avx.cc
@@ -10,21 +10,21 @@
     - AVX (Advanced Vector Extensions) - 256-bit operations (8 floats)
 */
 
-bool AJ::dsp::Gain::gainAVX(Float &buffer, AJ::error::IErrorHandler &handler){
+bool AJ::dsp::gain::Gain::gainAVX(Float &buffer, AJ::error::IErrorHandler &handler){
     // check valid indexes ranges
-    if(mParams->mEnd < mParams->mStart || mParams->mStart < 0 || 
-        mParams->mStart >= buffer.size() || mParams->mEnd >= buffer.size()){
+    if(mParams->End() < mParams->Start() || mParams->Start() < 0 || 
+        mParams->Start() >= buffer.size() || mParams->End() >= buffer.size()){
         const std::string message = "invalid indexes for gain effect.";
         handler.onError(error::Error::InvalidEffectParameters, message);
         return false;
     }
 
-    const __m256 gain = _mm256_set1_ps(mParams->mGain);
+    const __m256 gain = _mm256_set1_ps(mParams->Gain());
     const __m256 max_val = _mm256_set1_ps(1.0f);
     const __m256 min_val = _mm256_set1_ps(-1.0f);
 
     sample_pos i;
-    for(i = mParams->mStart; i + 7 <= mParams->mEnd; i += 8){
+    for(i = mParams->Start(); i + 7 <= mParams->End(); i += 8){
         __m256 samples = _mm256_mul_ps( // multiply current samples by gain value
             _mm256_loadu_ps(&buffer[i]), // laod 8 current samples
             gain
@@ -42,7 +42,7 @@ bool AJ::dsp::Gain::gainAVX(Float &buffer, AJ::error::IErrorHandler &handler){
     }
 
     // calculate the rest if there.
-    for(i; i <= mParams->mEnd; ++i){
+    for(i; i <= mParams->End(); ++i){
         calculate_gain_sample(buffer[i]);
     }
 

--- a/src/dsp/normalization/gain.cc
+++ b/src/dsp/normalization/gain.cc
@@ -4,7 +4,7 @@
 #include "core/types.h"
 #include "core/error_handler.h"
 
-bool AJ::dsp::Normalization::gain(Float &buffer, AJ::error::IErrorHandler &handler){
+bool AJ::dsp::normalization::Normalization::gain(Float &buffer, AJ::error::IErrorHandler &handler){
     if(mParams->Gain() == 1.0f) return true;
     
 #if defined(__AVX__)
@@ -16,15 +16,15 @@ bool AJ::dsp::Normalization::gain(Float &buffer, AJ::error::IErrorHandler &handl
     return gainNaive(buffer, handler);
 }
 
-bool AJ::dsp::Normalization::gainNaive(Float &buffer, AJ::error::IErrorHandler &handler){
-    if(mParams->mEnd < mParams->mStart || mParams->mStart < 0 || 
-        mParams->mStart >= buffer.size() || mParams->mEnd >= buffer.size()){
+bool AJ::dsp::normalization::Normalization::gainNaive(Float &buffer, AJ::error::IErrorHandler &handler){
+    if(mParams->End() < mParams->Start() || mParams->Start() < 0 || 
+        mParams->Start() >= buffer.size() || mParams->End() >= buffer.size()){
         const std::string message = "invalid indexes for gain effect.";
         handler.onError(error::Error::InvalidEffectParameters, message);
         return false;
     }
 
-    for(sample_pos i = mParams->mStart; i <= mParams->mEnd; ++i){
+    for(sample_pos i = mParams->Start(); i <= mParams->End(); ++i){
         buffer[i] *= mParams->Gain();
     }
 

--- a/src/dsp/normalization/gain_avx.cc
+++ b/src/dsp/normalization/gain_avx.cc
@@ -10,10 +10,10 @@
     - AVX (Advanced Vector Extensions) - 256-bit operations (8 floats)
 */
 
-bool AJ::dsp::Normalization::gainAVX(Float &buffer, AJ::error::IErrorHandler &handler){
+bool AJ::dsp::normalization::Normalization::gainAVX(Float &buffer, AJ::error::IErrorHandler &handler){
     // check valid indexes ranges
-    if(mParams->mEnd < mParams->mStart || mParams->mStart < 0 || 
-        mParams->mStart >= buffer.size() || mParams->mEnd >= buffer.size()){
+    if(mParams->End() < mParams->Start() || mParams->Start() < 0 || 
+        mParams->Start() >= buffer.size() || mParams->End() >= buffer.size()){
         const std::string message = "invalid indexes for gain effect.";
         handler.onError(error::Error::InvalidEffectParameters, message);
         return false;
@@ -22,7 +22,7 @@ bool AJ::dsp::Normalization::gainAVX(Float &buffer, AJ::error::IErrorHandler &ha
     const __m256 gain = _mm256_set1_ps(mParams->Gain());
 
     sample_pos i;
-    for(i = mParams->mStart; i + 7 <= mParams->mEnd; i += 8){
+    for(i = mParams->Start(); i + 7 <= mParams->End(); i += 8){
         __m256 samples = _mm256_mul_ps( // multiply current samples by gain value
             _mm256_loadu_ps(&buffer[i]), // laod 8 current samples
             gain
@@ -37,7 +37,7 @@ bool AJ::dsp::Normalization::gainAVX(Float &buffer, AJ::error::IErrorHandler &ha
     }
 
     // calculate the rest if there.
-    for(i; i <= mParams->mEnd; ++i){
+    for(i; i <= mParams->End(); ++i){
         buffer[i] *= mParams->Gain();
     }
 

--- a/src/dsp/reverb/reverb.cc
+++ b/src/dsp/reverb/reverb.cc
@@ -5,6 +5,28 @@
 #include "core/error_handler.h"
 #include "core/effect_params.h"
 
+std::shared_ptr<AJ::dsp::reverb::ReverbParams> AJ::dsp::reverb::ReverbParams::create(Params &params,
+    AJ::error::IErrorHandler &handler){
+    std::shared_ptr<ReverbParams> reverbParams = std::make_shared<ReverbParams>(PrivateTag{});
+        
+    if(params.mStart > params.mEnd || params.mStart < 0) {
+        const std::string message = "invalid range indexes parameters for reverb effect.\n";
+        handler.onError(error::Error::InvalidEffectParameters, message);
+
+        return nullptr;
+    }
+
+    reverbParams->setStart(params.mStart);
+    reverbParams->setEnd(params.mEnd);
+    reverbParams->setDelayMS(params.mDelayMS);
+    reverbParams->setWetMix(params.mWetMix);
+    reverbParams->setDryMix(params.mDryMix);
+    reverbParams->setSamplerate(params.mSamplerate);
+    reverbParams->setGain(params.mGain);
+
+    return reverbParams;
+}
+
 bool AJ::dsp::reverb::Reverb::setParams(std::shared_ptr<EffectParams> params, AJ::error::IErrorHandler &handler) {
     std::shared_ptr<ReverbParams> reverbParams = std::dynamic_pointer_cast<ReverbParams>(params);
     // if reverbParams is nullptr that means it's not a shared_ptr of ReverbParams
@@ -12,6 +34,10 @@ bool AJ::dsp::reverb::Reverb::setParams(std::shared_ptr<EffectParams> params, AJ
         const std::string message = "Effect parameters must be of type ReverbParams for this effect.\n";
         handler.onError(error::Error::InvalidEffectParameters, message);
         return false;
+    }
+
+    for (auto &all_pass : mAllPassFilters) {
+        all_pass = std::make_unique<AllPassFilter>(reverbParams->Samplerate());
     }
 
     mParams = reverbParams; 
@@ -25,14 +51,14 @@ bool AJ::dsp::reverb::Reverb::checkValidIndxes(Float &buffer, AJ::error::IErrorH
         return false;
     }
 
-    if (mParams->mStart < 0 || mParams->mEnd < mParams->mStart || mParams->mEnd >= buffer.size()) {
+    if (mParams->Start() < 0 || mParams->End() < mParams->Start() || mParams->End() >= buffer.size()) {
         const std::string message = "invalid start/End indexes for reverb effect.\n";
         handler.onError(error::Error::InvalidEffectParameters, message);
         return false;
     }
 
     // calculate total required delay in samples
-    float total_delay_ms = mParams->mDelayMS;  // base delay
+    float total_delay_ms = mParams->DelayMS();  // base delay
     
     // Add maximum comb filter delay
     total_delay_ms += std::max({
@@ -45,7 +71,7 @@ bool AJ::dsp::reverb::Reverb::checkValidIndxes(Float &buffer, AJ::error::IErrorH
     total_delay_ms += 89.27f;  // all-pass filter delay
     
     // Convert to samples
-    sample_pos required_samples = static_cast<sample_pos>((total_delay_ms / 1000.0f) * mParams->mSamplerate);
+    sample_pos required_samples = static_cast<sample_pos>((total_delay_ms / 1000.0f) * mParams->Samplerate());
     
     // We need enough samples after our current position for the delay
     if (buffer.size() < (required_samples * 2)) {  // Double the requirement for safety
@@ -57,8 +83,8 @@ bool AJ::dsp::reverb::Reverb::checkValidIndxes(Float &buffer, AJ::error::IErrorH
         return false;
     }
     
-    // Make sure we have enough samples remaining after 'mParams->mStart'
-    if ((buffer.size() - mParams->mStart) < required_samples) {
+    // Make sure we have enough samples remaining after 'mParams->Start()'
+    if ((buffer.size() - mParams->Start()) < required_samples) {
         const std::string message = "buffer too small for reverb delay.\n";
 
         handler.onError(error::Error::InvalidEffectParameters, message);
@@ -73,18 +99,18 @@ bool AJ::dsp::reverb::Reverb::process(Float &buffer, AJ::error::IErrorHandler &h
     if(!checkValidIndxes(buffer, handler)) return false;
 
     // set the comb filters.
-    sample_c size = mParams->mEnd - mParams->mStart + 1;
-    mCombFilters[0]->setDelay(mParams->mDelayMS, mParams->mSamplerate, size, handler);
-    mCombFilters[0]->setGain(mParams->mGain);
+    sample_c size = mParams->End() - mParams->Start() + 1;
+    mCombFilters[0]->setDelay(mParams->DelayMS(), mParams->Samplerate(), size, handler);
+    mCombFilters[0]->setGain(mParams->Gain());
 
-    mCombFilters[1]->setDelay(mParams->mDelayMS + COMB_FILTER_1_DELAY, mParams->mSamplerate, size, handler);
-    mCombFilters[1]->setGain(mParams->mGain);
+    mCombFilters[1]->setDelay(mParams->DelayMS() + COMB_FILTER_1_DELAY, mParams->Samplerate(), size, handler);
+    mCombFilters[1]->setGain(mParams->Gain());
 
-    mCombFilters[2]->setDelay(mParams->mDelayMS + COMB_FILTER_2_DELAY, mParams->mSamplerate, size, handler);
-    mCombFilters[2]->setGain(mParams->mGain);
+    mCombFilters[2]->setDelay(mParams->DelayMS() + COMB_FILTER_2_DELAY, mParams->Samplerate(), size, handler);
+    mCombFilters[2]->setGain(mParams->Gain());
 
-    mCombFilters[3]->setDelay(mParams->mDelayMS + COMB_FILTER_3_DELAY, mParams->mSamplerate, size, handler);
-    mCombFilters[3]->setGain(mParams->mGain);
+    mCombFilters[3]->setDelay(mParams->DelayMS() + COMB_FILTER_3_DELAY, mParams->Samplerate(), size, handler);
+    mCombFilters[3]->setGain(mParams->Gain());
 
 
     Float output(size, 0.0f);
@@ -94,13 +120,13 @@ bool AJ::dsp::reverb::Reverb::process(Float &buffer, AJ::error::IErrorHandler &h
     Float comb4_out(size, 0.0f);
 
 
-    for(sample_c i = mParams->mStart; i <= mParams->mEnd; ++i){
-        sample_t s1 = mCombFilters[0]->process(buffer, comb1_out, i, mParams->mStart);
-        sample_t s2 = mCombFilters[1]->process(buffer, comb2_out, i, mParams->mStart);
-        sample_t s3 = mCombFilters[2]->process(buffer, comb3_out, i, mParams->mStart);
-        sample_t s4 = mCombFilters[3]->process(buffer, comb4_out, i, mParams->mStart);
+    for(sample_c i = mParams->Start(); i <= mParams->End(); ++i){
+        sample_t s1 = mCombFilters[0]->process(buffer, comb1_out, i, mParams->Start());
+        sample_t s2 = mCombFilters[1]->process(buffer, comb2_out, i, mParams->Start());
+        sample_t s3 = mCombFilters[2]->process(buffer, comb3_out, i, mParams->Start());
+        sample_t s4 = mCombFilters[3]->process(buffer, comb4_out, i, mParams->Start());
 
-        output[i - mParams->mStart] = (s1 + s2 + s3 + s4) / 4; // normalization.
+        output[i - mParams->Start()] = (s1 + s2 + s3 + s4) / 4; // normalization.
     }
 
     // sequential processing for all pass filters 
@@ -108,10 +134,10 @@ bool AJ::dsp::reverb::Reverb::process(Float &buffer, AJ::error::IErrorHandler &h
     all_pass_out = mAllPassFilters[1]->process(all_pass_out);
 
     // wet and dry mixing and copying into main buffer
-    size_t j = mParams->mStart;
+    size_t j = mParams->Start();
     sample_t sample;
     for(size_t i = 0; i < size; ++i, ++j){
-        sample = mParams->mWetMix * all_pass_out[i] + mParams->mDryMix * buffer[j];
+        sample = mParams->WetMix() * all_pass_out[i] + mParams->DryMix() * buffer[j];
         buffer[j] = std::clamp(sample, -1.0f, 1.0f); 
     }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -19,26 +19,28 @@ int main(){
         return 0;
     }
 
-    // std::shared_ptr<AJ::dsp::reverb::ReverbParams> params;
-    auto params = std::make_shared<AJ::dsp::reverb::ReverbParams>();
+    AJ::dsp::reverb::Params params;
 
-    params->mDelayMS = 40.0f;
-    params->mDryMix = 0.3f;
-    params->mWetMix = 0.7f;
-    params->mGain = 0.7f;
-    params->mSamplerate = audio->mInfo.samplerate;
-    params->mStart = 0;
-    params->mEnd = (audio->mInfo.length / audio->mInfo.channels) - 1; // end is included.
+    params.mDelayMS = 40.0f;
+    params.mDryMix = 0.3f;
+    params.mWetMix = 0.7f;
+    params.mGain = 0.7f;
+    params.mSamplerate = audio->mInfo.samplerate;
+    params.mStart = 0;
+    params.mEnd = (audio->mInfo.length / audio->mInfo.channels) - 1; // end is included.
+
+
+    auto reverbParams = AJ::dsp::reverb::ReverbParams::create(params, handler);
 
     std::cout << "start processing reverb effect.\n";
-    if(engine->applyEffect(audio->pAudio->at(0), AJ::Effect::reverb, params, handler)){
+    if(engine->applyEffect(audio->pAudio->at(0), AJ::Effect::reverb, reverbParams, handler)){
         std::cout << "first channel processed successfully.\n";
     } else {
         return 0;
     }
 
     if(audio->mInfo.channels == 2){ // stereo
-        if(engine->applyEffect(audio->pAudio->at(1), AJ::Effect::reverb, params, handler)){
+        if(engine->applyEffect(audio->pAudio->at(1), AJ::Effect::reverb, reverbParams, handler)){
             std::cout << "second channel processed successfully.\n";
         } else {
             return 0;

--- a/test/reverb/reverb_tests.cc
+++ b/test/reverb/reverb_tests.cc
@@ -32,8 +32,7 @@ private:
                                           float delayMS, float dryMix, float wetMix, float gain) {
         using namespace AJ;
         using namespace AJ::io;
-        using namespace AJ::dsp;
-        using namespace AJ::dsp::reverb;
+        using namespace AJ::dsp::reverb;  // Already using correct namespace
 
         std::string input_path = std::string(audio_dir) + "/" + filename;
         WAV_File wav;
@@ -54,7 +53,7 @@ private:
         const auto& info = wav.mInfo;
         assert(info.channels == expected_channels);
 
-        Reverb reverb(info.samplerate);
+        Reverb reverb;
         AudioSamples pAudio = wav.pAudio;
         assert(pAudio);
 
@@ -78,15 +77,20 @@ private:
                           (info.length / info.channels) - min_samples); // leave room for tail
         }
 
-        ReverbParams params;
-        params.mStart = start;
-        params.mEnd = end;
-        params.mDelayMS = delayMS;
-        params.mDryMix = dryMix;
-        params.mWetMix = wetMix;
-        params.mGain = gain;
-        params.mSamplerate = info.samplerate;
-        assert(reverb.setParams(std::make_shared<ReverbParams>(params), errorHandler));
+        // Create reverb parameters using the Params struct
+        Params reverbParams{
+            delayMS,          // mDelayMS
+            wetMix,           // mWetMix
+            dryMix,           // mDryMix
+            info.samplerate,  // mSamplerate
+            gain,            // mGain
+            start,           // mStart
+            end             // mEnd
+        };
+
+        auto params = ReverbParams::create(reverbParams, errorHandler);
+        assert(params);
+        assert(reverb.setParams(params, errorHandler));
 
         auto process_start = std::chrono::high_resolution_clock::now();
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -17,7 +17,7 @@ int main() {
         std::cout << "Current working directory: " << cwd << std::endl;
     }
 
-    // Run MP3 file tests
+    // // Run MP3 file tests
     // MP3FileTests::run_all();
 
     // // Run WAV file tests
@@ -32,8 +32,8 @@ int main() {
     // // Run Reverb Tests
     // ReverbTests::run_all();
 
-    // // Run Fade Tests
-    // FadeTests::run_all();
+    // Run Fade Tests
+    FadeTests::run_all();
 
     // Run Normalization Tests
     NormalizationTests::run_all();


### PR DESCRIPTION
…onstructors

- Added dedicated Params structs for Echo, Fade, Gain, and Normalization effects
- Updated factory create() methods to accept Params structs by reference
- Documented all Params structs and factory methods with detailed validation rules
- Implemented inline default constructors using PrivateTag to ensure consistent defaults
- Fixed linker errors by defining missing constructors
- Applied gain clamping and validation across effects for safety